### PR TITLE
Fix typos and variable names in rule visitor and reporter comments

### DIFF
--- a/source/TSQLLint.Core/Interfaces/IRuleVisitor.cs
+++ b/source/TSQLLint.Core/Interfaces/IRuleVisitor.cs
@@ -6,6 +6,6 @@ namespace TSQLLint.Core.Interfaces
 {
     public interface IRuleVisitor
     {
-        void VisitRules(string path, IEnumerable<IRuleException> igoredRules, Stream sqlFileStream);
+        void VisitRules(string path, IEnumerable<IRuleException> ignoredRules, Stream sqlFileStream);
     }
 }

--- a/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
+++ b/source/TSQLLint.Infrastructure/Reporters/ConsoleReporter.cs
@@ -53,7 +53,7 @@ namespace TSQLLint.Infrastructure.Reporters
             }
 
             // If --fix is turned on sometimes the program runs a couple times to fixed issues
-            // caused by fixing another rule. This prevents double or tripple counting.
+            // caused by fixing another rule. This prevents double or triple counting.
             if (!ReporterMuted)
             {
                 switch (violation.Severity)

--- a/source/TSQLLint.Infrastructure/Rules/CaseSensitiveVariablesRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/CaseSensitiveVariablesRule.cs
@@ -27,9 +27,9 @@ namespace TSQLLint.Infrastructure.Rules
 
         public override void Visit(DeclareVariableStatement node)
         {
-            foreach (var decalaration in node.Declarations)
+            foreach (var declaration in node.Declarations)
             {
-                variableNames.Add(decalaration.VariableName.Value);
+                variableNames.Add(declaration.VariableName.Value);
             }
         }
 

--- a/source/TSQLLint.Infrastructure/Rules/CountStarRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/CountStarRule.cs
@@ -46,7 +46,7 @@ namespace TSQLLint.Infrastructure.Rules
                 if (paramVisitor.IsWildcard)
                 {
                     var whileCard = paramVisitor.Expression;
-                    actions.RepaceInlineAt(whileCard.StartLine - 1, whileCard.StartColumn - 1, "1");
+                    actions.ReplaceInlineAt(whileCard.StartLine - 1, whileCard.StartColumn - 1, "1");
                 }
             }
         }

--- a/source/TSQLLint.Infrastructure/Rules/CrossDatabaseTransactionRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/CrossDatabaseTransactionRule.cs
@@ -55,10 +55,10 @@ namespace TSQLLint.Infrastructure.Rules
 
             public override void Visit(CommitTransactionStatement node)
             {
-                var firstUncomitted = TransactionLists.LastOrDefault(x => x.Commit == null);
-                if (firstUncomitted != null)
+                var firstUncommitted = TransactionLists.LastOrDefault(x => x.Commit == null);
+                if (firstUncommitted != null)
                 {
-                    firstUncomitted.Commit = node;
+                    firstUncommitted.Commit = node;
                 }
             }
         }

--- a/source/TSQLLint.Infrastructure/Rules/InformationSchemaRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/InformationSchemaRule.cs
@@ -86,7 +86,7 @@ namespace TSQLLint.Infrastructure.Rules
 
                 if (newFrom != null)
                 {
-                    actions.RepaceInlineAt(fromClause.StartLine - 1, fromClause.StartColumn - 1,
+                    actions.ReplaceInlineAt(fromClause.StartLine - 1, fromClause.StartColumn - 1,
                     newFrom, oldFrom.Length);
                 }
             }
@@ -110,7 +110,7 @@ namespace TSQLLint.Infrastructure.Rules
             var firstWhereLine = whereClause.ScriptTokenStream[whereClause.FirstTokenIndex].Line;
             var lastWhereLine = whereClause.ScriptTokenStream[whereClause.LastTokenIndex].Line;
 
-            // Delete mutliline where
+            // Delete multiline where
             var anyDeleted = false;
             for (int line = lastWhereLine; line > firstWhereLine; line--)
             {
@@ -129,7 +129,7 @@ namespace TSQLLint.Infrastructure.Rules
                     && x.Text != "\n")
                 .Select(x => x.Text));
 
-            actions.RepaceInlineAt(whereClause.StartLine - 1, whereClause.StartColumn - 1,
+            actions.ReplaceInlineAt(whereClause.StartLine - 1, whereClause.StartColumn - 1,
                 newWhere, oldWhere.Length);
         }
 

--- a/source/TSQLLint.Infrastructure/Rules/KeywordCapitalizationRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/KeywordCapitalizationRule.cs
@@ -58,7 +58,7 @@ namespace TSQLLint.Infrastructure.Rules
             {
                 var errorWord = new Regex(@"\w+").Matches(line[startCharIndex..]).First().Value;
 
-                actions.RepaceInlineAt(lineIndex, startCharIndex, errorWord.ToUpper());
+                actions.ReplaceInlineAt(lineIndex, startCharIndex, errorWord.ToUpper());
             }
         }
 

--- a/source/TSQLLint.Infrastructure/Rules/SetVariableRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/SetVariableRule.cs
@@ -37,7 +37,7 @@ namespace TSQLLint.Infrastructure.Rules
             if (regex.Success)
             {
                 var isStartOfLine = regex.ValueSpan.Length <= SET_LENGTH + 1;
-                actions.RepaceInlineAt(lineIndex, isStartOfLine ? regex.Index : regex.Index + 1, SELECT, SET_LENGTH);
+                actions.ReplaceInlineAt(lineIndex, isStartOfLine ? regex.Index : regex.Index + 1, SELECT, SET_LENGTH);
             }
         }
     }

--- a/source/TSQLLint.Tests/Helpers/HelperTests/RuleViolationCompareTests.cs
+++ b/source/TSQLLint.Tests/Helpers/HelperTests/RuleViolationCompareTests.cs
@@ -9,7 +9,7 @@ namespace TSQLLint.Tests.Helpers.HelperTests
 {
     public class RuleViolationCompareTests
     {
-        public static readonly object[] NonEquilaventRuleViolations =
+        public static readonly object[] NonEquivalentRuleViolations =
         {
             new object[]
             {
@@ -37,7 +37,7 @@ namespace TSQLLint.Tests.Helpers.HelperTests
             }
         };
 
-        public static readonly object[] EquilaventRuleViolations =
+        public static readonly object[] EquivalentRuleViolations =
         {
             new object[]
             {
@@ -52,15 +52,15 @@ namespace TSQLLint.Tests.Helpers.HelperTests
         private readonly RuleViolationComparer ruleViolationComparer = new RuleViolationComparer();
 
         [Test]
-        [TestCaseSource(nameof(EquilaventRuleViolations))]
-        public void CompareEquilaventRulesTest(List<RuleViolation> ruleViolations)
+        [TestCaseSource(nameof(EquivalentRuleViolations))]
+        public void CompareEquivalentRulesTest(List<RuleViolation> ruleViolations)
         {
             Assert.AreEqual(0, ruleViolationComparer.Compare(ruleViolations[0], ruleViolations[1]));
         }
 
         [Test]
-        [TestCaseSource(nameof(NonEquilaventRuleViolations))]
-        public void CompareNonEquilaventRulesTest(List<RuleViolation> ruleViolations)
+        [TestCaseSource(nameof(NonEquivalentRuleViolations))]
+        public void CompareNonEquivalentRulesTest(List<RuleViolation> ruleViolations)
         {
             Assert.AreEqual(-1, ruleViolationComparer.Compare(ruleViolations[0], ruleViolations[1]));
         }

--- a/source/TSQLLint.Tests/UnitTests/LintingRuleExceptions/IgnoreLintingRulesTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/LintingRuleExceptions/IgnoreLintingRulesTests.cs
@@ -30,7 +30,7 @@ namespace TSQLLint.Tests.UnitTests.LintingRuleExceptions
             get
             {
                 yield return new TestCaseData(@"integration-test-two.sql", string.Empty, IntegrationTestTwoRuleViolations, 1).SetName("Ignore one select star rule enforce another");
-                yield return new TestCaseData(@"global-disable.sql", string.Empty, new List<RuleViolation>(), 1).SetName("Globally disable rule varnings");
+                yield return new TestCaseData(@"global-disable.sql", string.Empty, new List<RuleViolation>(), 1).SetName("Globally disable rule warnings");
                 yield return new TestCaseData(@"global-enable-without-disbling.sql", string.Empty, GlobalEnableWithoutDisableRuleViolations, 1).SetName("Globally enable without disabling first");
                 yield return new TestCaseData(@"enable-without-disbling.sql", string.Empty, EnableWithoutDisableRuleViolations, 1).SetName("Globally enable without disabling first");
             }

--- a/source/TSQLLint.Tests/UnitTests/Parser/SqlRuleVisitorTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/SqlRuleVisitorTests.cs
@@ -114,7 +114,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
         }
 
         [Test]
-        public void VisitRules_NullFragent_ShouldReportErrors()
+        public void VisitRules_NullFragment_ShouldReportErrors()
         {
             // arrange
             var path = System.IO.Path.GetFullPath(System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, @"UnitTests/Parser/invalid-characters.sql"));
@@ -138,7 +138,7 @@ namespace TSQLLint.Tests.UnitTests.Parser
         }
 
         [Test]
-        public void VisitRules_NullFragentWithIgnores_ShouldNotReportErrors()
+        public void VisitRules_NullFragmentWithIgnores_ShouldNotReportErrors()
         {
             // arrange
             var path = System.IO.Path.GetFullPath(System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, @"UnitTests/Parser/invalid-characters-ignore-rules.sql"));

--- a/source/TSQLLint/Application.cs
+++ b/source/TSQLLint/Application.cs
@@ -80,7 +80,7 @@ namespace TSQLLint
                     reporter.ClearViolations();
                     fileProcessor.ProcessList(commandLineOptions.LintPath);
 
-                    // Prevent the reportor from douple or tripple counting errors if the while loop evaulates to true;
+                    // Prevent the reporter from double or triple counting errors if the while loop evaluates to true;
                     reporter.ReporterMuted = true;
 
                     if (response.ShouldFix)


### PR DESCRIPTION
Correct typos and improve variable names for clarity in the rule visitor and reporter components.

fixed #14