### PR TITLE
Enhance dynamic parser version handling and add unit tests for FragmentBuilder

### DIFF
--- a/source/TSQLLint.Infrastructure/Parser/FragmentBuilder.cs
+++ b/source/TSQLLint.Infrastructure/Parser/FragmentBuilder.cs
@@ -66,7 +66,7 @@ namespace TSQLLint.Infrastructure.Parser
                 }
             }
 
-            return parser ?? new TSql120Parser(true);
+            return parser ?? new TSql160Parser(true);
         }
     }
 }

--- a/source/TSQLLint.Infrastructure/Parser/FragmentBuilder.cs
+++ b/source/TSQLLint.Infrastructure/Parser/FragmentBuilder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using TSQLLint.Core;
 using TSQLLint.Core.Interfaces;
@@ -52,21 +54,64 @@ namespace TSQLLint.Infrastructure.Parser
         private static TSqlParser GetSqlParser(int compatabilityLevel)
         {
             compatabilityLevel = CompatabilityLevel.Validate(compatabilityLevel);
-            var fullyQualifiedName = string.Format("Microsoft.SqlServer.TransactSql.ScriptDom.TSql{0}Parser", compatabilityLevel);
 
-            TSqlParser parser = null;
-
-            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            var availableVersions = GetAvailableParserVersions();
+            if (availableVersions.Count == 0)
             {
-                var parserType = asm.GetType(fullyQualifiedName);
-                if (parserType != null)
+                return new TSql120Parser(true);
+            }
+
+            var bestVersion = GetBestParserVersion(availableVersions, compatabilityLevel);
+            var parserType = typeof(TSqlParser).Assembly.GetType(GetParserTypeName(bestVersion));
+            if (parserType == null)
+            {
+                return new TSql120Parser(true);
+            }
+
+            return (TSqlParser)Activator.CreateInstance(parserType, new object[] { true });
+        }
+
+        private static IReadOnlyList<int> GetAvailableParserVersions()
+        {
+            var versions = new List<int>();
+            var assembly = typeof(TSqlParser).Assembly;
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException exception)
+            {
+                types = exception.Types.Where(type => type != null).ToArray();
+            }
+
+            foreach (var type in types)
+            {
+                var name = type.Name;
+                if (!name.StartsWith("TSql", StringComparison.Ordinal) || !name.EndsWith("Parser", StringComparison.Ordinal))
                 {
-                    parser = (TSqlParser)Activator.CreateInstance(parserType, new object[] { true });
-                    break;
+                    continue;
+                }
+
+                var versionText = name.Substring(4, name.Length - 4 - "Parser".Length);
+                if (int.TryParse(versionText, out var version))
+                {
+                    versions.Add(version);
                 }
             }
 
-            return parser ?? new TSql120Parser(true);
+            return versions.Distinct().OrderBy(x => x).ToList();
+        }
+
+        private static int GetBestParserVersion(IReadOnlyList<int> availableVersions, int compatabilityLevel)
+        {
+            var bestMatch = availableVersions.LastOrDefault(x => x <= compatabilityLevel);
+            return bestMatch != 0 ? bestMatch : availableVersions.Last();
+        }
+
+        private static string GetParserTypeName(int compatabilityLevel)
+        {
+            return string.Format("Microsoft.SqlServer.TransactSql.ScriptDom.TSql{0}Parser", compatabilityLevel);
         }
     }
 }

--- a/source/TSQLLint.Infrastructure/Parser/ViolationFixer.cs
+++ b/source/TSQLLint.Infrastructure/Parser/ViolationFixer.cs
@@ -63,14 +63,7 @@ namespace TSQLLint.Infrastructure.Parser
                         }
 
                         var lines = new List<string>(fileLines);
-                        try
-                        {
-                            Rules[violation.RuleName].FixViolation(lines, violation, fileLineActions);
-                        }
-                        catch
-                        {
-                            // Skip fixes that cannot be applied due to parse errors.
-                        }
+                        Rules[violation.RuleName].FixViolation(lines, violation, fileLineActions);
                     }
                 }
 

--- a/source/TSQLLint.Infrastructure/Parser/ViolationFixer.cs
+++ b/source/TSQLLint.Infrastructure/Parser/ViolationFixer.cs
@@ -63,7 +63,14 @@ namespace TSQLLint.Infrastructure.Parser
                         }
 
                         var lines = new List<string>(fileLines);
-                        Rules[violation.RuleName].FixViolation(lines, violation, fileLineActions);
+                        try
+                        {
+                            Rules[violation.RuleName].FixViolation(lines, violation, fileLineActions);
+                        }
+                        catch
+                        {
+                            // Skip fixes that cannot be applied due to parse errors.
+                        }
                     }
                 }
 

--- a/source/TSQLLint.Tests/UnitTests/Parser/FragmentBuilderTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/Parser/FragmentBuilderTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using NUnit.Framework;
+using TSQLLint.Infrastructure.Parser;
+
+namespace TSQLLint.Tests.UnitTests.Parser
+{
+    [TestFixture]
+    public class FragmentBuilderTests
+    {
+        [Test]
+        public void CreateOrAlterProcedure_ParsesWithoutErrors()
+        {
+            var builder = new FragmentBuilder(150);
+            using var reader = new StringReader("CREATE OR ALTER PROCEDURE dbo.Test AS SELECT 1;");
+
+            var fragment = builder.GetFragment(reader, out var errors);
+
+            Assert.NotNull(fragment);
+            Assert.IsEmpty(errors);
+        }
+    }
+}


### PR DESCRIPTION
Improve the handling of dynamic parser versions based on compatibility levels and add unit tests to ensure the FragmentBuilder correctly parses SQL fragments without errors.

Fixed #6