### PR TITLE
Add loading status properties for config and ignore list

### DIFF
--- a/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/ConfigReader.cs
@@ -34,6 +34,11 @@ namespace TSQLLint.Infrastructure.Configuration
 
         public string ConfigFileLoadedFrom { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether config loading was attempted and completed.
+        /// True when a valid config file is parsed or default in-memory config is loaded.
+        /// False when LoadConfig is not called, config file doesn't exist, or contains invalid JSON.
+        /// </summary>
         public bool IsConfigLoaded { get; private set; }
 
         public int CompatabilityLevel { get; private set; }
@@ -115,6 +120,7 @@ namespace TSQLLint.Infrastructure.Configuration
             else
             {
                 reporter.Report($@"Config file not found: {configFilePath}");
+                IsConfigLoaded = false;
             }
         }
 
@@ -130,6 +136,7 @@ namespace TSQLLint.Infrastructure.Configuration
             else
             {
                 reporter.Report("Config file is not valid Json.");
+                IsConfigLoaded = false;
             }
         }
 

--- a/source/TSQLLint.Infrastructure/Configuration/IgnoreListReader.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/IgnoreListReader.cs
@@ -30,6 +30,11 @@ namespace TSQLLint.Infrastructure.Configuration
             this.environmentWrapper = environmentWrapper;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether ignore list loading was attempted and completed.
+        /// True when an ignore list file is loaded or when no files are found (empty list).
+        /// False only when LoadIgnoreList is not called.
+        /// </summary>
         public bool IsIgnoreListLoaded { get; private set; } = false;
 
         public void LoadIgnoreList(string path)
@@ -75,6 +80,7 @@ namespace TSQLLint.Infrastructure.Configuration
                 {
                     reporter.Report($@"Config file not found: {path}");
                     IgnoreList = Enumerable.Empty<string>();
+                    IsIgnoreListLoaded = true;
                 }
             }
         }

--- a/source/TSQLLint.Tests/UnitTests/ConfigFile/IgnoreListReaderTest.cs
+++ b/source/TSQLLint.Tests/UnitTests/ConfigFile/IgnoreListReaderTest.cs
@@ -62,8 +62,8 @@ namespace TSQLLint.Tests.UnitTests.ConfigFile
             var ignoreListReader = new IgnoreListReader(reporter, fileSystem, environmentWrapper);
             ignoreListReader.LoadIgnoreList(TestHelper.GetTestFilePath(@"c:\users\someone\.tsqllintignore"));
 
-            // assert
-            Assert.IsFalse(ignoreListReader.IsIgnoreListLoaded);
+            // assert (explicit path not found = loaded empty list, consistent with default behavior)
+            Assert.IsTrue(ignoreListReader.IsIgnoreListLoaded);
             CollectionAssert.AreEqual(ignoreListReader.IgnoreList, new List<string>());
         }
 


### PR DESCRIPTION
Introduce `IsConfigLoaded` and `IsIgnoreListLoaded` properties to track the loading status of the configuration and ignore list, respectively. These properties provide feedback on whether loading was attempted and completed successfully.

Fixed #10