### PR TITLE
Add nested block comments rule with associated tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ TSQLLint rules may be set to "off", "warning", or "error". Rules that are violat
     "linked-server": "error",
     "multi-table-alias": "error",
     "named-constraint": "error",
+    "nested-block-comments": "warning",
     "non-sargable": "error",
     "object-property": "error",
     "print-statement": "error",

--- a/documentation/rules/nested-block-comments.md
+++ b/documentation/rules/nested-block-comments.md
@@ -1,0 +1,28 @@
+# Avoid Nested Block Comments
+
+## Rule Details
+
+Nested block comments are valid T-SQL, but some SQL tooling does not support them and can fail to parse a script.
+
+Examples of **incorrect** code for this rule:
+
+```tsql
+SELECT *
+FROM dbo.Foo
+/* outer comment
+   /* inner comment */
+   more text
+*/
+WHERE Name = 'Bar'
+```
+
+Examples of **correct** code for this rule:
+
+```tsql
+SELECT *
+FROM dbo.Foo
+/* outer comment
+-- inner comment
+*/
+WHERE Name = 'Bar'
+```

--- a/schema.json
+++ b/schema.json
@@ -68,6 +68,10 @@
         "named-constraint": {
           "$ref": "#/definitions/rule"
         },
+        "nested-block-comments": {
+          "$ref": "#/definitions/rule",
+          "description": "Warns on nested block comments because some SQL tooling does not support them"
+        },
         "non-sargable": {
           "$ref": "#/definitions/rule"
         },

--- a/source/TSQLLint.Infrastructure/Configuration/ConfigFileGenerator.cs
+++ b/source/TSQLLint.Infrastructure/Configuration/ConfigFileGenerator.cs
@@ -24,6 +24,7 @@ namespace TSQLLint.Infrastructure.Configuration
         ""linked-server"": ""error"",
         ""multi-table-alias"": ""error"",
         ""named-constraint"": ""error"",
+        ""nested-block-comments"": ""warning"",
         ""non-sargable"": ""error"",
         ""object-property"": ""error"",
         ""print-statement"": ""error"",

--- a/source/TSQLLint.Infrastructure/Parser/RuleVisitorFriendlyNameTypeMap.cs
+++ b/source/TSQLLint.Infrastructure/Parser/RuleVisitorFriendlyNameTypeMap.cs
@@ -31,6 +31,7 @@ namespace TSQLLint.Infrastructure.Parser
             { "linked-server", typeof(LinkedServerRule) },
             { "multi-table-alias", typeof(MultiTableAliasRule) },
             { "named-constraint", typeof(NamedConstraintRule) },
+            { "nested-block-comments", typeof(NestedBlockCommentsRule) },
             { "non-sargable", typeof(NonSargableRule) },
             { "object-property", typeof(ObjectPropertyRule) },
             { "print-statement", typeof(PrintStatementRule) },

--- a/source/TSQLLint.Infrastructure/Rules/NestedBlockCommentsRule.cs
+++ b/source/TSQLLint.Infrastructure/Rules/NestedBlockCommentsRule.cs
@@ -1,0 +1,92 @@
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using System;
+using TSQLLint.Core.Interfaces;
+using TSQLLint.Infrastructure.Rules.Common;
+
+namespace TSQLLint.Infrastructure.Rules
+{
+    public class NestedBlockCommentsRule : BaseRuleVisitor, ISqlRule
+    {
+        public NestedBlockCommentsRule(Action<string, string, int, int> errorCallback)
+            : base(errorCallback)
+        {
+        }
+
+        public override string RULE_NAME => "nested-block-comments";
+
+        public override string RULE_TEXT => "Nested block comments can cause parsing errors in tools that do not support them";
+
+        public override void Visit(TSqlScript node)
+        {
+            if (node?.ScriptTokenStream == null)
+            {
+                return;
+            }
+
+            for (var index = 0; index <= node.LastTokenIndex; index++)
+            {
+                var token = node.ScriptTokenStream[index];
+
+                if (token.TokenType != TSqlTokenType.MultilineComment)
+                {
+                    continue;
+                }
+
+                if (TryGetNestedCommentPosition(token, out var line, out var column))
+                {
+                    errorCallback(RULE_NAME, RULE_TEXT, line, column);
+                }
+            }
+        }
+
+        private int GetColumnOffsetForNestedComment(TSqlParserToken token, int index, int lastLineStartIndex, int lineOffset)
+        {
+            if (lineOffset == 0)
+            {
+                return GetColumnNumber(token) + index;
+            }
+
+            return index - lastLineStartIndex + 1;
+        }
+
+        private int GetLineOffsetForNestedComment(string commentText, int index, out int lastLineStartIndex)
+        {
+            var lineOffset = 0;
+            lastLineStartIndex = 0;
+
+            for (var i = 0; i < index; i++)
+            {
+                if (commentText[i] == '\n')
+                {
+                    lineOffset++;
+                    lastLineStartIndex = i + 1;
+                }
+            }
+
+            return lineOffset;
+        }
+
+        private bool TryGetNestedCommentPosition(TSqlParserToken token, out int line, out int column)
+        {
+            line = 0;
+            column = 0;
+
+            if (string.IsNullOrEmpty(token.Text))
+            {
+                return false;
+            }
+
+            var index = token.Text.IndexOf("/*", 2, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            var lineOffset = GetLineOffsetForNestedComment(token.Text, index, out var lastLineStartIndex);
+            line = GetLineNumber(token) + lineOffset;
+            column = GetColumnOffsetForNestedComment(token, index, lastLineStartIndex, lineOffset);
+
+            return true;
+        }
+    }
+}

--- a/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/NestedBlockCommentsRuleTests.cs
+++ b/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/NestedBlockCommentsRuleTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using TSQLLint.Infrastructure.Rules;
+using TSQLLint.Infrastructure.Rules.RuleViolations;
+
+namespace TSQLLint.Tests.UnitTests.LintingRules
+{
+    public class NestedBlockCommentsRuleTests
+    {
+        private const string RuleName = "nested-block-comments";
+
+        private static readonly object[] TestCases =
+        {
+            new object[]
+            {
+                "nested-block-comments-no-error", new List<RuleViolation>()
+            },
+            new object[]
+            {
+                "nested-block-comments-one-error", new List<RuleViolation>
+                {
+                    new RuleViolation(RuleName, 4, 4)
+                }
+            },
+            new object[]
+            {
+                "nested-block-comments-same-line-error", new List<RuleViolation>
+                {
+                    new RuleViolation(RuleName, 1, 10)
+                }
+            }
+        };
+
+        [TestCaseSource(nameof(TestCases))]
+        public void TestRule(string testFileName, List<RuleViolation> expectedRuleViolations)
+        {
+            RulesTestHelper.RunRulesTest(RuleName, testFileName, typeof(NestedBlockCommentsRule), expectedRuleViolations);
+        }
+    }
+}

--- a/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-no-error.sql
+++ b/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-no-error.sql
@@ -1,0 +1,5 @@
+SELECT *
+FROM dbo.Foo
+/* outer comment */
+WHERE Name = 'Bar'
+GO

--- a/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-one-error.sql
+++ b/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-one-error.sql
@@ -1,0 +1,8 @@
+SELECT *
+FROM dbo.Foo
+/* outer comment
+   /* inner comment */
+   more text
+*/
+WHERE Name = 'Bar'
+GO

--- a/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-same-line-error.sql
+++ b/source/TSQLLint.Tests/UnitTests/LintingRules/nested-block-comments/test-files/nested-block-comments-same-line-error.sql
@@ -1,0 +1,3 @@
+/* outer /* inner */ still */
+SELECT 1
+GO


### PR DESCRIPTION
Introduce a new rule to warn against nested block comments in T-SQL, as they can lead to parsing issues in some SQL tools. Include tests and documentation to support the implementation.

Fixed #4